### PR TITLE
Need to read in binary mode to improve portability - otherwise can cause problems

### DIFF
--- a/osmnodepbf.py
+++ b/osmnodepbf.py
@@ -32,7 +32,7 @@ class Parser:
     def __init__(self,filename):
         """Initialize the class with the filename of the pbf you want to parse"""
         self.filename = filename
-        self.fpbf=open(self.filename, "r")
+        self.fpbf=open(self.filename, "rb")
         self.tags = {}    # content is {key: set(values)}, ...
         self.nodes = []
         self.blobhead=fileformat_pb2.BlobHeader()


### PR DESCRIPTION
'rb' not just 'r'
